### PR TITLE
Unflatten for loop input in tests

### DIFF
--- a/t/01-basics.t
+++ b/t/01-basics.t
@@ -8,7 +8,7 @@ my @rationals = 3 => [3],
                 3.245 => [3, 4, 12, 4],
                 -4.2 => [-5, 1, 4];
                 
-for flat @rationals>>.kv -> $rational, $cf-form {
+for @rationals>>.kv -> ($rational, $cf-form) {
     my $cf = Math::ContinuedFraction.new($rational);
     isa-ok $cf, Math::ContinuedFraction, "We made a Math::ContinuedFraction object for $rational";
     is $cf.a, $cf-form, "With the correct value";
@@ -68,7 +68,7 @@ my @values = # cf => [name, .sign, .truncate, floor, ceiling, round]
              Math::ContinuedFraction.new(-34) => ["-34", -1, -34, -34, -34, -34],
              Math::ContinuedFraction.new(-403.1) => ["-403.1", -1, -403, -404, -403, -403];
 
-for flat @values>>.kv -> $cf, [$name, $sign, $truncate, $floor, $ceiling, $round] {
+for @values>>.kv -> ($cf, [$name, $sign, $truncate, $floor, $ceiling, $round]) {
     isa-ok $cf, Math::ContinuedFraction, "$name is a ContinuedFraction";
     is $cf.sign, $sign, "$name .sign is $sign";
     isa-ok $cf.sign, Int, "$name .sign is Int";


### PR DESCRIPTION
It looks like this code didn't get updated after the Great List Refactor (well, that's my best guess!); key-value lists no longer need to be flattened before input to for loops, also the arguments to a for loop now need to be enclosed in parens.  This commit allows the test suite to pass again.