### PR TITLE
Fix pre-glr tests

### DIFF
--- a/t/01-basics.t
+++ b/t/01-basics.t
@@ -8,7 +8,7 @@ my @rationals = 3 => [3],
                 3.245 => [3, 4, 12, 4],
                 -4.2 => [-5, 1, 4];
                 
-for flat @rationals>>.kv -> $rational, $cf-form {
+for @rationals -> (:key($rational), :value($cf-form)) {
     my $cf = Math::ContinuedFraction.new($rational);
     isa-ok $cf, Math::ContinuedFraction, "We made a Math::ContinuedFraction object for $rational";
     is $cf.a, $cf-form, "With the correct value";
@@ -68,7 +68,7 @@ my @values = # cf => [name, .sign, .truncate, floor, ceiling, round]
              Math::ContinuedFraction.new(-34) => ["-34", -1, -34, -34, -34, -34],
              Math::ContinuedFraction.new(-403.1) => ["-403.1", -1, -403, -404, -403, -403];
 
-for flat @values>>.kv -> $cf, [$name, $sign, $truncate, $floor, $ceiling, $round] {
+for @values -> (:key($cf), :value([$name, $sign, $truncate, $floor, $ceiling, $round])) {
     isa-ok $cf, Math::ContinuedFraction, "$name is a ContinuedFraction";
     is $cf.sign, $sign, "$name .sign is $sign";
     isa-ok $cf.sign, Int, "$name .sign is Int";


### PR DESCRIPTION
Behavior of the code was changed before v6.c release¹, this commit
adjusts the code accordingly using fancy destructuring. Now tests pass
correctly.

¹ – https://gist.github.com/0e12ff62fe81d7286b26c864d4e21f35